### PR TITLE
fix(tables): Don't serialize table metadata

### DIFF
--- a/Runtime/Generated/WhiskeyObjects/Generics.codegen.cs
+++ b/Runtime/Generated/WhiskeyObjects/Generics.codegen.cs
@@ -117,17 +117,13 @@ namespace FasterGames.Whiskey
         public List<ImmutableObjectTableEntry> TableEntries = new List<ImmutableObjectTableEntry>();
 
         /// <summary>
-        /// Editor preview of the weight in the table
+        /// The total weight in the table
         /// </summary>
-        [ReadOnly]
-        [SerializeField]
         protected float TotalWeightInTable;
 
         /// <summary>
-        /// Editor preview of the dirty state flag
+        /// The dirty state flag
         /// </summary>
-        [ReadOnly]
-        [SerializeField]
         protected bool IsDirty = true;
 
         /// <inheritdoc />

--- a/Runtime/WhiskeyObjects.tt
+++ b/Runtime/WhiskeyObjects.tt
@@ -111,17 +111,13 @@
         public List<ImmutableObjectTableEntry> TableEntries = new List<ImmutableObjectTableEntry>();
 
         /// <summary>
-        /// Editor preview of the weight in the table
+        /// The total weight in the table
         /// </summary>
-        [ReadOnly]
-        [SerializeField]
         protected float TotalWeightInTable;
 
         /// <summary>
-        /// Editor preview of the dirty state flag
+        /// The dirty state flag
         /// </summary>
-        [ReadOnly]
-        [SerializeField]
         protected bool IsDirty = true;
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixes a bug where things look great in th editor, but `IsDirty = false` is persisted in the object model, meaning in builds everything is borked.